### PR TITLE
Check if body is present

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ function middleware({ algorithms = Object.keys(ALGORITHMS), required = false } =
   }
 
   return async function instanceDigest(context, next) {
+    const { request: { rawBody } } = context;
     const digest = context.get('Digest');
 
     if (!required && !digest) {
@@ -56,7 +57,7 @@ function middleware({ algorithms = Object.keys(ALGORITHMS), required = false } =
       throw new WantDigestError({ algorithms });
     }
 
-    if (context.request.length === 0) {
+    if (!rawBody || rawBody.length === 0) {
       throw new InvalidDigestError();
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -99,6 +99,7 @@ describe('index', () => {
     });
 
     it('should return 400 if the digest algorithm is invalid', () => {
+      app.use(body());
       app.use(middleware({ algorithms: ['sha-256'] }));
 
       return request(server)
@@ -110,6 +111,7 @@ describe('index', () => {
     });
 
     it('should return 400 if the digest algorithm is not supported', () => {
+      app.use(body());
       app.use(middleware({ algorithms: ['sha-256', 'sha-512'] }));
 
       return request(server)


### PR DESCRIPTION
Validate size of body instead of the `Content-Length` header to prevent abuse.